### PR TITLE
トップページの背景・タイトルのUI微調整

### DIFF
--- a/numbuyer_front/src/index.js
+++ b/numbuyer_front/src/index.js
@@ -28,7 +28,8 @@ if (process.env.NODE_ENV !== "development") {
 
 ReactDOM.render(
   <ThemeProvider theme={theme}>
-    <Helmet bodyAttributes={{style: 'background: linear-gradient(25deg, #4682b4, #000000)'}}/>
+    <Helmet htmlAttributes={{ style: 'height: 100%' }}
+            bodyAttributes={{ style: 'background: #000000 linear-gradient(25deg, #4682b4, #000000); height: 100%' }} />
     <Provider store={store}>
       <ConnectedRouter history={history}>
         <App />

--- a/numbuyer_front/src/templates/Top.jsx
+++ b/numbuyer_front/src/templates/Top.jsx
@@ -392,17 +392,17 @@ const Top = () => {
                         <Grid container alignItems="center">
                             <Grid item xs={3} />
                             <Grid item xs={6}>
-                                <Grid container>
+                                <Grid container sx={{ display: 'flex'}}>
                                     {/* ロゴ画像 */}
-                                    <Grid item xs={2}>
+                                    <Grid item xs={2} sx={{ alignSelf: 'center'}}>
                                         <MainLogo src={logo} />
                                     </Grid>
                                     {/* タイトル画像 */}
-                                    <Grid item xs={8}>
+                                    <Grid item xs={8} sx={{ alignSelf: 'center'}}>
                                         <MainTitle src={title} />
                                     </Grid>
                                     {/* バージョン情報 */}
-                                    <Grid item xs={2}>
+                                    <Grid item xs={2} sx={{ alignSelf: 'flex-end'}}>
                                         <VerMsg sx={{ color: grey[50], fontSize: '1.5em' }}>( {Constants.VERSION} )</VerMsg>
                                     </Grid>
                                 </Grid>
@@ -582,17 +582,17 @@ const Top = () => {
                     {/* ウィンドウサイズがモバイル版 */}
                     <BackMobile>
                         {/* ロゴ画像 */}
-                        <Grid container>
+                        <Grid container sx={{ display: 'flex'}}>
                             <Grid item xs={2} />
-                            <Grid item xs={1} >
+                            <Grid item xs={1.2} sx={{ alignSelf: 'center'}}>
                                 <div><MainLogoMobile src={logo} /></div>
                             </Grid>
                             {/* タイトル画像 */}
-                            <Grid item xs={7}>
+                            <Grid item xs={6.8} sx={{ alignSelf: 'center'}}>
                                 <MainTitleMobile src={title} />
                             </Grid>
                             {/* バージョン情報 */}
-                            <Grid item xs={2}>
+                            <Grid item xs={2} sx={{ alignSelf: 'flex-end'}}>
                                 <VerMsgMobile sx={{ color: grey[50], fontSize: '0.75em' }}>( {Constants.VERSION} )</VerMsgMobile>
                             </Grid>
                         </Grid>

--- a/numbuyer_front/src/templates/Top.jsx
+++ b/numbuyer_front/src/templates/Top.jsx
@@ -582,11 +582,13 @@ const Top = () => {
                     {/* ウィンドウサイズがモバイル版 */}
                     <BackMobile>
                         {/* ロゴ画像 */}
-                        <div><MainLogoMobile src={logo} /></div>
                         <Grid container>
                             <Grid item xs={2} />
+                            <Grid item xs={1} >
+                                <div><MainLogoMobile src={logo} /></div>
+                            </Grid>
                             {/* タイトル画像 */}
-                            <Grid item xs={8}>
+                            <Grid item xs={7}>
                                 <MainTitleMobile src={title} />
                             </Grid>
                             {/* バージョン情報 */}

--- a/numbuyer_front/src/templates/Top.jsx
+++ b/numbuyer_front/src/templates/Top.jsx
@@ -581,20 +581,21 @@ const Top = () => {
                 <>
                     {/* ウィンドウサイズがモバイル版 */}
                     <BackMobile>
-                        {/* ロゴ画像 */}
                         <Grid container sx={{ display: 'flex'}}>
-                            <Grid item xs={2} />
+                            <Grid item xs={1.8} />
+                            {/* ロゴ画像 */}
                             <Grid item xs={1.2} sx={{ alignSelf: 'center'}}>
                                 <div><MainLogoMobile src={logo} /></div>
                             </Grid>
                             {/* タイトル画像 */}
-                            <Grid item xs={6.8} sx={{ alignSelf: 'center'}}>
+                            <Grid item xs={7.2} sx={{ alignSelf: 'center'}}>
                                 <MainTitleMobile src={title} />
                             </Grid>
                             {/* バージョン情報 */}
-                            <Grid item xs={2} sx={{ alignSelf: 'flex-end'}}>
+                            <Grid item xs={0.8} sx={{ alignSelf: 'flex-end'}}>
                                 <VerMsgMobile sx={{ color: grey[50], fontSize: '0.75em' }}>( {Constants.VERSION} )</VerMsgMobile>
                             </Grid>
+                            <Grid item xs={1} />
                         </Grid>
                         <MenuCardMobile>
                             {/* プレイヤー名入力エリア */}

--- a/numbuyer_front/src/templates/theme.js
+++ b/numbuyer_front/src/templates/theme.js
@@ -30,13 +30,12 @@ export const MainLogo = styled('img')({
 // メインタイトル
 export const MainTitle = styled('img')({
   width: '100%',
-  marginTop: '5%',
 });
 
 // バージョンメッセージ
-export const VerMsg = styled('p')({
-  marginTop: '50%',
+export const VerMsg = styled('div')({
   textAlign: 'left',
+  marginBottom: '12%',
 });
 
 // トップ・ロビー画面の背景

--- a/numbuyer_front/src/templates/theme.js
+++ b/numbuyer_front/src/templates/theme.js
@@ -47,14 +47,14 @@ export const Back = styled('div')({
 // 言語設定ボタン
 export const LangIcon = styled(GTranslateIcon)({
   color: grey[50],
-  fontSize: '3em',
+  fontSize: '2.8em',
   margin: 0,
 });
 
 // チュートリアルアイコン
 export const TutorialIcon = styled(MenuBookIcon)({
   color: grey[50],
-  fontSize: '3em',
+  fontSize: '2.8em',
   margin: 0,
 });
 

--- a/numbuyer_front/src/templates/themeMobile.js
+++ b/numbuyer_front/src/templates/themeMobile.js
@@ -29,7 +29,7 @@ export const MainTitleMobile = styled('img')({
 
 // バージョンメッセージ
 export const VerMsgMobile = styled('div')({
-  textAlign: 'left',
+  textAlign: 'right',
   marginBottom: '12%',
 });
 

--- a/numbuyer_front/src/templates/themeMobile.js
+++ b/numbuyer_front/src/templates/themeMobile.js
@@ -18,7 +18,8 @@ export const theme = createTheme({
 
 // メインロゴ
 export const MainLogoMobile = styled('img')({
-  width: '25%',
+  width: '92%',
+  marginRight: '8%',
 });
 
 // メインタイトル
@@ -34,7 +35,7 @@ export const VerMsgMobile = styled('p')({
 
 // トップ・ロビー画面の背景
 export const BackMobile = styled('div')({
-  paddingTop: '5%',
+  paddingTop: '15%',
 });
 
 // 言語設定ボタン

--- a/numbuyer_front/src/templates/themeMobile.js
+++ b/numbuyer_front/src/templates/themeMobile.js
@@ -28,9 +28,9 @@ export const MainTitleMobile = styled('img')({
 });
 
 // バージョンメッセージ
-export const VerMsgMobile = styled('p')({
-  marginTop: '30%',
+export const VerMsgMobile = styled('div')({
   textAlign: 'left',
+  marginBottom: '12%',
 });
 
 // トップ・ロビー画面の背景


### PR DESCRIPTION
・モバイル版タイトルとロゴを横並びに変更
・flexを使ってタイトルのgridを調整。バージョン情報 ( Beta ) を下に表示されるように変更
・背景のグラデーションが画面サイズちょうどになるように変更

問題なさそうだったらマージおなしゃす